### PR TITLE
Feature/timer frame

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>26d53683-6746-4040-ad07-f671f8e2b27e</groupId>
     <artifactId>mule-custom-logger</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.mule.extensions</groupId>
         <artifactId>mule-modules-parent</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.0</version>
     </parent>
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>26d53683-6746-4040-ad07-f671f8e2b27e</groupId>
     <artifactId>mule-custom-logger</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>mule-extension</packaging>
 
     <parent>
         <groupId>org.mule.extensions</groupId>
         <artifactId>mule-modules-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.3</version>
     </parent>
     <build>
         <pluginManagement>

--- a/src/main/java/com/avio/customlogger/internal/CustomLoggerConfiguration.java
+++ b/src/main/java/com/avio/customlogger/internal/CustomLoggerConfiguration.java
@@ -12,7 +12,7 @@ import org.mule.runtime.extension.api.annotation.param.display.Summary;
  * This class represents an extension configuration, values set in this class are commonly used across multiple
  * operations since they represent something core from the extension.
  */
-@Operations(CustomLoggerOperation.class)
+@Operations({CustomLoggerOperation.class, CustomLoggerTimerFrameOperations.class})
 public class CustomLoggerConfiguration {
 
     @Parameter

--- a/src/main/java/com/avio/customlogger/internal/CustomLoggerConfiguration.java
+++ b/src/main/java/com/avio/customlogger/internal/CustomLoggerConfiguration.java
@@ -12,7 +12,7 @@ import org.mule.runtime.extension.api.annotation.param.display.Summary;
  * This class represents an extension configuration, values set in this class are commonly used across multiple
  * operations since they represent something core from the extension.
  */
-@Operations({CustomLoggerOperation.class, CustomLoggerTimerFrameOperations.class})
+@Operations({CustomLoggerOperation.class, CustomLoggerTimerScopeOperations.class})
 public class CustomLoggerConfiguration {
 
     @Parameter

--- a/src/main/java/com/avio/customlogger/internal/CustomLoggerTimerFrameOperations.java
+++ b/src/main/java/com/avio/customlogger/internal/CustomLoggerTimerFrameOperations.java
@@ -1,0 +1,80 @@
+package com.avio.customlogger.internal;
+
+import com.avio.customlogger.internal.model.LogLocationInfoProperty;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ObjectMessage;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
+import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
+import org.mule.runtime.extension.api.runtime.route.Chain;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class CustomLoggerTimerFrameOperations {
+
+    private Logger logger;
+
+    public void timerFrame(String timerName,
+                           String category,
+                           @ParameterGroup(name = "App Level") CustomLoggerConfiguration customLoggerConfiguration,
+                           @ParameterGroup(name = "Options") LogLocationInfoProperty logLocationInfoProperty,
+                           ComponentLocation location,
+                           Chain operations,
+                           CompletionCallback<Object, Object> callback) {
+        this.logger = LogManager.getLogger(category);
+        Map<String, Object> logContent = new HashMap<>();
+        logContent.put("timer_name", timerName);
+        logContent.put("app_name", customLoggerConfiguration.getApp_name());
+        logContent.put("app_version", customLoggerConfiguration.getApp_version());
+        logContent.put("env", customLoggerConfiguration.getEnv());
+
+        if (logLocationInfoProperty.logLocationInfo) {
+            Map<String, String> locationInfo = new HashMap<>();
+            locationInfo.put("location", location.getLocation());
+            locationInfo.put("root_container", location.getRootContainerName());
+            locationInfo.put("component", location.getComponentIdentifier().getIdentifier().toString());
+            locationInfo.put("file_name", location.getFileName().orElse(""));
+            locationInfo.put("line_in_file", String.valueOf(location.getLineInFile().orElse(null)));
+
+            logContent.put("location", locationInfo);
+        }
+
+
+        Map<String, Object> beforeFrame = new HashMap<>();
+        beforeFrame.put("message", timerName + " timer frame starting");
+        beforeFrame.put("trace_point", "FRAME_START");
+        logContent.put("log", beforeFrame);
+        logContent.put("timestamp", Instant.now().toString());
+        logger.debug(new ObjectMessage(logContent));
+
+        long startTime = System.currentTimeMillis();
+        operations.process(
+                result -> {
+                    Map<String, Object> afterFrame = new HashMap<>();
+                    long elapsedMilliseconds = System.currentTimeMillis() - startTime;
+                    afterFrame.put("message", timerName + " timer frame completed with milliseconds elapsed: "  + elapsedMilliseconds);
+                    afterFrame.put("elapsed_milliseconds", elapsedMilliseconds);
+                    afterFrame.put("trace_point", "FRAME_END");
+                    logContent.put("log", afterFrame);
+                    logContent.put("timestamp", Instant.now().toString());
+                    logger.info(new ObjectMessage(logContent));
+                    callback.success(result);
+                },
+                (error, previous) -> {
+                    Map<String, Object> afterFrame = new HashMap<>();
+                    long elapsedMilliseconds = System.currentTimeMillis() - startTime;
+                    afterFrame.put("message", timerName + " timer frame errored out with milliseconds elapsed: "  + elapsedMilliseconds);
+                    afterFrame.put("elapsed_milliseconds", elapsedMilliseconds);
+                    afterFrame.put("trace_point", "FRAME_EXCEPTION");
+                    logContent.put("log", afterFrame);
+                    logContent.put("timestamp", Instant.now().toString());
+                    logger.info(new ObjectMessage(logContent));
+                    callback.error(error);
+                });
+    }
+
+}

--- a/src/main/java/com/avio/customlogger/internal/CustomLoggerTimerFrameOperations.java
+++ b/src/main/java/com/avio/customlogger/internal/CustomLoggerTimerFrameOperations.java
@@ -46,7 +46,7 @@ public class CustomLoggerTimerFrameOperations {
 
         Map<String, Object> beforeFrame = new HashMap<>();
         beforeFrame.put("message", timerName + " timer frame starting");
-        beforeFrame.put("trace_point", "FRAME_START");
+        beforeFrame.put("trace_point", "TIMER_START");
         logContent.put("log", beforeFrame);
         logContent.put("timestamp", Instant.now().toString());
         logger.debug(new ObjectMessage(logContent));
@@ -58,7 +58,7 @@ public class CustomLoggerTimerFrameOperations {
                     long elapsedMilliseconds = System.currentTimeMillis() - startTime;
                     afterFrame.put("message", timerName + " timer frame completed with milliseconds elapsed: "  + elapsedMilliseconds);
                     afterFrame.put("elapsed_milliseconds", elapsedMilliseconds);
-                    afterFrame.put("trace_point", "FRAME_END");
+                    afterFrame.put("trace_point", "TIMER_END");
                     logContent.put("log", afterFrame);
                     logContent.put("timestamp", Instant.now().toString());
                     logger.info(new ObjectMessage(logContent));
@@ -69,7 +69,7 @@ public class CustomLoggerTimerFrameOperations {
                     long elapsedMilliseconds = System.currentTimeMillis() - startTime;
                     afterFrame.put("message", timerName + " timer frame errored out with milliseconds elapsed: "  + elapsedMilliseconds);
                     afterFrame.put("elapsed_milliseconds", elapsedMilliseconds);
-                    afterFrame.put("trace_point", "FRAME_EXCEPTION");
+                    afterFrame.put("trace_point", "TIMER_EXCEPTION");
                     logContent.put("log", afterFrame);
                     logContent.put("timestamp", Instant.now().toString());
                     logger.info(new ObjectMessage(logContent));

--- a/src/main/java/com/avio/customlogger/internal/CustomLoggerTimerScopeOperations.java
+++ b/src/main/java/com/avio/customlogger/internal/CustomLoggerTimerScopeOperations.java
@@ -14,11 +14,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 
-public class CustomLoggerTimerFrameOperations {
+public class CustomLoggerTimerScopeOperations {
 
     private Logger logger;
 
-    public void timerFrame(String timerName,
+    public void timerScope(String timerName,
                            String category,
                            @ParameterGroup(name = "App Level") CustomLoggerConfiguration customLoggerConfiguration,
                            @ParameterGroup(name = "Options") LogLocationInfoProperty logLocationInfoProperty,
@@ -44,33 +44,33 @@ public class CustomLoggerTimerFrameOperations {
         }
 
 
-        Map<String, Object> beforeFrame = new HashMap<>();
-        beforeFrame.put("message", timerName + " timer frame starting");
-        beforeFrame.put("trace_point", "TIMER_START");
-        logContent.put("log", beforeFrame);
+        Map<String, Object> beforeScope = new HashMap<>();
+        beforeScope.put("message", timerName + " timer scope starting");
+        beforeScope.put("trace_point", "TIMER_START");
+        logContent.put("log", beforeScope);
         logContent.put("timestamp", Instant.now().toString());
         logger.debug(new ObjectMessage(logContent));
 
         long startTime = System.currentTimeMillis();
         operations.process(
                 result -> {
-                    Map<String, Object> afterFrame = new HashMap<>();
+                    Map<String, Object> afterScope = new HashMap<>();
                     long elapsedMilliseconds = System.currentTimeMillis() - startTime;
-                    afterFrame.put("message", timerName + " timer frame completed with milliseconds elapsed: "  + elapsedMilliseconds);
-                    afterFrame.put("elapsed_milliseconds", elapsedMilliseconds);
-                    afterFrame.put("trace_point", "TIMER_END");
-                    logContent.put("log", afterFrame);
+                    afterScope.put("message", timerName + " timer scope completed with milliseconds elapsed: "  + elapsedMilliseconds);
+                    afterScope.put("elapsed_milliseconds", elapsedMilliseconds);
+                    afterScope.put("trace_point", "TIMER_END");
+                    logContent.put("log", afterScope);
                     logContent.put("timestamp", Instant.now().toString());
                     logger.info(new ObjectMessage(logContent));
                     callback.success(result);
                 },
                 (error, previous) -> {
-                    Map<String, Object> afterFrame = new HashMap<>();
+                    Map<String, Object> afterScope = new HashMap<>();
                     long elapsedMilliseconds = System.currentTimeMillis() - startTime;
-                    afterFrame.put("message", timerName + " timer frame errored out with milliseconds elapsed: "  + elapsedMilliseconds);
-                    afterFrame.put("elapsed_milliseconds", elapsedMilliseconds);
-                    afterFrame.put("trace_point", "TIMER_EXCEPTION");
-                    logContent.put("log", afterFrame);
+                    afterScope.put("message", timerName + " timer scope errored out with milliseconds elapsed: "  + elapsedMilliseconds);
+                    afterScope.put("elapsed_milliseconds", elapsedMilliseconds);
+                    afterScope.put("trace_point", "TIMER_EXCEPTION");
+                    logContent.put("log", afterScope);
                     logContent.put("timestamp", Instant.now().toString());
                     logger.info(new ObjectMessage(logContent));
                     callback.error(error);


### PR DESCRIPTION
This feature adds a Scope component that logs a DEBUG message when starting and an INFO when ending (including the elapsed time. The log messages look like the following:

DEBUG start
`{
  "thread" : "[MuleRuntime].cpuLight.22: [mule-explorer].otherFlow.CPU_LITE @9b5c8d4",
  "level" : "DEBUG",
  "loggerName" : "com.avioconsulting",
  "message" : {
    "timer_name" : "my-timer-frame",
    "app_name" : "mule-explorer",
    "app_version" : "1.0.0",
    "log" : {
      "trace_point" : "TIMER_START",
      "message" : "my-timer-frame timer frame starting"
    },
    "env" : "dev",
    "timestamp" : "2020-04-10T16:21:46.275Z"
  },
  "endOfBatch" : true,
  "loggerFqcn" : "org.apache.logging.log4j.spi.AbstractLogger",
  "instant" : {
    "epochSecond" : 1586535706,
    "nanoOfSecond" : 275000000
  },
  "threadId" : 68,
  "threadPriority" : 5
}`

INFO end
`{
  "thread" : "[MuleRuntime].cpuLight.22: [mule-explorer].otherFlow.CPU_LITE @9b5c8d4",
  "level" : "INFO",
  "loggerName" : "com.avioconsulting",
  "message" : {
    "timer_name" : "my-timer-frame",
    "app_name" : "mule-explorer",
    "app_version" : "1.0.0",
    "log" : {
      "trace_point" : "TIMER_END",
      "elapsed_milliseconds" : 620,
      "message" : "my-timer-frame timer frame completed with milliseconds elapsed: 620"
    },
    "env" : "dev",
    "timestamp" : "2020-04-10T16:21:46.895Z"
  },
  "endOfBatch" : true,
  "loggerFqcn" : "org.apache.logging.log4j.spi.AbstractLogger",
  "instant" : {
    "epochSecond" : 1586535706,
    "nanoOfSecond" : 895000000
  },
  "threadId" : 68,
  "threadPriority" : 5
}`

I've attached a screenshot of the configuration panel for the timer. The values in the "App Level" section are autofilled to match the settings in the AVIO Core Config global configuration. However we cannot use an @Config annotation inside a Scope definition.
![image](https://user-images.githubusercontent.com/61711437/79006154-264c6e80-7b1e-11ea-8ccf-d961e07b3cf5.png)
