### PR TITLE
feat: export opentelemetry trace context via message attributes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ One of the reasons for developing this custom module is to feed JSON logs to log
 * Tracepoints compatibility to measure request, response times and such.
 
 # Changes
+## 2.2.0
+* Added
+	- Support for AVIO OpenTelemtry Module
+    - If you are using the OpenTelemetry Module then all logs will export the following messageAttributes to every log
+      - traceId
+      - traceIdLongLowPart
+      - spanId
+      - spanIdLong
+    - If you are not utilizing the OpenTelemetry module then none of these values will be added to messageAttributes
 ## 2.1.1
 * Fixes
 	- Fixed implementation to only create and register one Notification Listener. Duplicates were being created and registered leading to duplicate flow logs

--- a/README.md
+++ b/README.md
@@ -17,15 +17,9 @@ One of the reasons for developing this custom module is to feed JSON logs to log
 * Tracepoints compatibility to measure request, response times and such.
 
 # Changes
-## 2.2.0
-* Added
-	- Support for AVIO OpenTelemtry Module
-    - If you are using the OpenTelemetry Module then all logs will export the following messageAttributes to every log
-      - traceId
-      - traceIdLongLowPart
-      - spanId
-      - spanIdLong
-    - If you are not utilizing the OpenTelemetry module then none of these values will be added to messageAttributes
+
+## Please refer to Github releases for continued changelog
+
 ## 2.1.1
 * Fixes
 	- Fixed implementation to only create and register one Notification Listener. Duplicates were being created and registered leading to duplicate flow logs
@@ -109,6 +103,16 @@ Example of logger configuration that is utilizing `encryptionAlgorithm` and `enc
 ```
 	<avio-logger:config name="ts-logger-test-config-encryption" doc:name="AVIO Logger Config" doc:id="e4f60146-7ee7-404a-a177-ac187c874bdd" applicationVersion="#[p('api.version')]" defaultCategory="com.avioconsulting.mule" encryptionAlgorithm="PBEWithHmacSHA512AndAES_128" encryptionPassword="${secure::encryption.password}"/>
 ```
+
+# Support for automatically including trace and span IDs in each log (v2.2.x)
+
+This feature is designed to be used in tandom with the [Mule OpenTelemetry Module.](https://github.com/avioconsulting/mule-opentelemetry-module) If the Mule OpenTelemetry Module is included in your project, AVIO Logger will automatically include the following attributes in each log's `messageAttributes` section.
+	1. `traceId` - Trace id of the current request
+	2. `spanId` - Span Id for the component used for creating context
+	3. `spanIdLong` - Long number value of the `spanId` for services that require a long number for Span IDs (i.e DataDog)
+	4. `traceIdLongLowPart` - Long value of the Trace Id Low part
+
+If the OpenTelemetry Module is not in use, there is no configuration necessary and the logs will not include these additional messageAttributes. 
 
 
 # Using the Timer Scope

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.avioconsulting.mule</groupId>
     <artifactId>mule-custom-logger</artifactId>
     <name>Mule Custom Logger</name>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <description>Mule Custom Logger module that provides standard structured logging</description>
     <url>https://github.com/${project.github.repository}</url>

--- a/src/main/java/com/avioconsulting/mule/logger/api/processor/MessageAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/logger/api/processor/MessageAttributes.java
@@ -21,7 +21,7 @@ public class MessageAttributes {
   @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT]")
   @Expression(ExpressionSupport.REQUIRED)
   @ParameterDsl(allowInlineDefinition = false, allowReferences = false)
-  @DisplayName("Open Telemetry Context")
+  @DisplayName("OpenTelemetry Context")
   @Summary("The object that contains the open telemetry context variables to add the log message attributes. If you are using AVIO's Open Telemetry Module there is no more configuration necessary")
   private ParameterResolver<TypedValue<Object>> oTelContext;
   @Parameter

--- a/src/main/java/com/avioconsulting/mule/logger/api/processor/MessageAttributes.java
+++ b/src/main/java/com/avioconsulting/mule/logger/api/processor/MessageAttributes.java
@@ -4,20 +4,34 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.mule.runtime.api.meta.ExpressionSupport;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.dsl.xml.ParameterDsl;
 import org.mule.runtime.extension.api.annotation.param.NullSafe;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;
+import org.mule.runtime.extension.api.runtime.parameter.ParameterResolver;
 
 public class MessageAttributes {
 
+  @Parameter
+  @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT]")
+  @Expression(ExpressionSupport.REQUIRED)
+  @ParameterDsl(allowInlineDefinition = false, allowReferences = false)
+  @DisplayName("Open Telemetry Context")
+  @Summary("The object that contains the open telemetry context variables to add the log message attributes. If you are using AVIO's Open Telemetry Module there is no more configuration necessary")
+  private ParameterResolver<TypedValue<Object>> oTelContext;
   @Parameter
   @DisplayName("Message Attributes")
   @Optional
   @NullSafe
   @Summary("Discrete data elements you want to log as key value pairs.  Useful for adding data fields for reporting in log aggregation tools")
   private List<MessageAttribute> messageAttributes;
+
+  private Object oTelContextObject;
 
   public MessageAttributes() {
     this.messageAttributes = new ArrayList<>();
@@ -36,4 +50,26 @@ public class MessageAttributes {
     }
     return attributes;
   }
+
+  public ParameterResolver<TypedValue<Object>> getOTelContext() {
+    return oTelContext;
+  }
+
+  public void setOTelContext(ParameterResolver<TypedValue<Object>> oTelContext) {
+    this.oTelContext = oTelContext;
+  }
+
+  public Object getOTelContextObject() {
+    if (oTelContextObject != null) {
+      return oTelContextObject;
+    } else if (oTelContext != null) {
+      return oTelContext.resolve().getValue();
+    } else
+      return null;
+  }
+
+  public void setOTelContextObject(Object oTelContextObject) {
+    this.oTelContextObject = oTelContextObject;
+  }
+
 }

--- a/src/main/java/com/avioconsulting/mule/logger/internal/CustomLogger.java
+++ b/src/main/java/com/avioconsulting/mule/logger/internal/CustomLogger.java
@@ -3,6 +3,7 @@ package com.avioconsulting.mule.logger.internal;
 import com.avioconsulting.mule.logger.api.processor.AdditionalProperties;
 import com.avioconsulting.mule.logger.api.processor.ExceptionProperties;
 import com.avioconsulting.mule.logger.api.processor.LogProperties;
+import com.avioconsulting.mule.logger.api.processor.MessageAttribute;
 import com.avioconsulting.mule.logger.api.processor.MessageAttributes;
 import com.avioconsulting.mule.logger.internal.config.CustomLoggerConfiguration;
 import com.avioconsulting.mule.logger.internal.utils.CustomLoggerUtils;
@@ -75,6 +76,7 @@ public class CustomLogger {
       Level level = levelMap.get(logProperties.getLevel());
       String correlation = logProperties.getCorrelationId() != null ? logProperties.getCorrelationId()
           : correlationId;
+      Object oTelContext = messageAttributes.getOTelContextObject();
 
       Map<String, Object> logContext = new LinkedHashMap<>();
       logContext.put("timestamp", Instant.now().toString());
@@ -83,6 +85,26 @@ public class CustomLogger {
       logContext.put("env", environment);
       logContext.put("correlationId", correlation);
       logContext.put("message", logProperties.getMessage());
+
+      /*
+       * If oTelContext is not null, then add message attributes for traceId and
+       * spanId from the context
+       */
+      if (oTelContext != null) {
+        Map<String, String> oTelContextMap = (Map<String, String>) oTelContext;
+        MessageAttribute traceId = new MessageAttribute("traceId",
+            oTelContextMap.get("traceId"));
+        messageAttributes.getAttributeList().add(traceId);
+        MessageAttribute traceIdLongLowPart = new MessageAttribute("traceIdLongLowPart",
+            oTelContextMap.get("traceIdLongLowPart"));
+        messageAttributes.getAttributeList().add(traceIdLongLowPart);
+        MessageAttribute spanId = new MessageAttribute("spanId",
+            oTelContextMap.get("spanId"));
+        messageAttributes.getAttributeList().add(spanId);
+        MessageAttribute spanIdLong = new MessageAttribute("spanIdLong",
+            oTelContextMap.get("spanIdLong"));
+        messageAttributes.getAttributeList().add(spanIdLong);
+      }
       logContext.put("messageAttributes", messageAttributes.getAttributes());
 
       /*

--- a/src/main/java/com/avioconsulting/mule/logger/internal/CustomLoggerTimerScopeOperations.java
+++ b/src/main/java/com/avioconsulting/mule/logger/internal/CustomLoggerTimerScopeOperations.java
@@ -69,7 +69,8 @@ public class CustomLoggerTimerScopeOperations {
       long startTime = System.currentTimeMillis();
       MessageAttribute timerNameAtt = new MessageAttribute("timerName", timerName);
       messageAttributes.getAttributeList().add(timerNameAtt);
-      if (logProperties.getCategorySuffix() == null || logProperties.getCategorySuffix().equals("")) {
+      if (logProperties.getCategorySuffix() == null ||
+          logProperties.getCategorySuffix().equals("")) {
         logProperties.setCategorySuffix(DEFAULT_CATEGORY_SUFFIX);
       }
       operations.process(
@@ -78,11 +79,14 @@ public class CustomLoggerTimerScopeOperations {
             MessageAttribute elapsed = new MessageAttribute("elapsedTimeMs",
                 String.valueOf(elapsedMilliseconds));
             messageAttributes.getAttributeList().add(elapsed);
-            if (logProperties.getMessage() == null || logProperties.getMessage().equals("")) {
+            if (logProperties.getMessage() == null ||
+                logProperties.getMessage().equals("")) {
               logProperties.setMessage(
-                  "Timer scope [" + timerName + "] completed in " + elapsedMilliseconds + "ms");
+                  "Timer scope [" + timerName + "] completed in " + elapsedMilliseconds +
+                      "ms");
             }
-            logger.log(logProperties, messageAttributes, exceptionProperties, additionalProperties, config,
+            logger.log(logProperties, messageAttributes, exceptionProperties,
+                additionalProperties, config,
                 location, correlationId);
             callback.success(result);
           },
@@ -91,12 +95,14 @@ public class CustomLoggerTimerScopeOperations {
             MessageAttribute elapsed = new MessageAttribute("elapsedTimeMs",
                 String.valueOf(elapsedMilliseconds));
             messageAttributes.getAttributeList().add(elapsed);
-            if (logProperties.getMessage() == null || logProperties.getMessage().equals("")) {
+            if (logProperties.getMessage() == null ||
+                logProperties.getMessage().equals("")) {
               logProperties.setMessage("Timer scope [" + timerName + "] completed with errors in "
                   + elapsedMilliseconds + "ms");
             }
             logProperties.setLevel(LogProperties.LogLevel.ERROR);
-            logger.log(logProperties, messageAttributes, exceptionProperties, additionalProperties, config,
+            logger.log(logProperties, messageAttributes, exceptionProperties,
+                additionalProperties, config,
                 location, correlationId);
             callback.error(error);
           });

--- a/src/main/java/com/avioconsulting/mule/logger/internal/CustomLoggerTimerScopeOperations.java
+++ b/src/main/java/com/avioconsulting/mule/logger/internal/CustomLoggerTimerScopeOperations.java
@@ -42,7 +42,8 @@ public class CustomLoggerTimerScopeOperations {
   public void timerScope(@DisplayName(value = "Timer Name") String timerName,
       @ParameterGroup(name = "Log") LogProperties logProperties,
       @ParameterGroup(name = "Options") AdditionalProperties additionalProperties,
-      @DisplayName("Open Telemetry Context") @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT]") @Placement(tab = "Open Telemetry") ParameterResolver<TypedValue<Object>> oTelContext,
+      @DisplayName("OpenTelemetry Context") @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT]") @Placement(tab = "Message Attributes") ParameterResolver<TypedValue<Object>> oTelContext,
+
       ComponentLocation location,
       CorrelationInfo correlationInfo,
       Chain operations,

--- a/src/main/java/com/avioconsulting/mule/logger/internal/CustomLoggerTimerScopeOperations.java
+++ b/src/main/java/com/avioconsulting/mule/logger/internal/CustomLoggerTimerScopeOperations.java
@@ -7,11 +7,15 @@ import com.avioconsulting.mule.logger.internal.config.CustomLoggerConfiguration;
 import javax.inject.Inject;
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.extension.api.annotation.param.MediaType;
+import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.mule.runtime.extension.api.annotation.param.display.Placement;
 import org.mule.runtime.extension.api.runtime.parameter.CorrelationInfo;
+import org.mule.runtime.extension.api.runtime.parameter.ParameterResolver;
 import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
 import org.mule.runtime.extension.api.runtime.route.Chain;
 import org.slf4j.LoggerFactory;
@@ -38,6 +42,7 @@ public class CustomLoggerTimerScopeOperations {
   public void timerScope(@DisplayName(value = "Timer Name") String timerName,
       @ParameterGroup(name = "Log") LogProperties logProperties,
       @ParameterGroup(name = "Options") AdditionalProperties additionalProperties,
+      @DisplayName("Open Telemetry Context") @Optional(defaultValue = "#[vars.OTEL_TRACE_CONTEXT]") @Placement(tab = "Open Telemetry") ParameterResolver<TypedValue<Object>> oTelContext,
       ComponentLocation location,
       CorrelationInfo correlationInfo,
       Chain operations,
@@ -57,6 +62,7 @@ public class CustomLoggerTimerScopeOperations {
       CustomLogger logger = config.getLogger();
       ExceptionProperties exceptionProperties = new ExceptionProperties();
       MessageAttributes messageAttributes = new MessageAttributes();
+      messageAttributes.setOTelContext(oTelContext);
 
       String correlationId = correlationInfo.getCorrelationId();
       long startTime = System.currentTimeMillis();

--- a/src/main/java/com/avioconsulting/mule/logger/internal/listeners/CustomLoggerNotificationListener.java
+++ b/src/main/java/com/avioconsulting/mule/logger/internal/listeners/CustomLoggerNotificationListener.java
@@ -38,6 +38,11 @@ public class CustomLoggerNotificationListener
         CustomLogger logger = config.getLogger();
         LogProperties logProperties = new LogProperties();
         MessageAttributes messageAttributes = new MessageAttributes();
+        if (notification.getEvent().getVariables().get("OTEL_TRACE_CONTEXT") != null) {
+          Object oTelContextObject = notification.getEvent().getVariables().get("OTEL_TRACE_CONTEXT")
+              .getValue();
+          messageAttributes.setOTelContextObject(oTelContextObject);
+        }
         ExceptionProperties exceptionProperties = new ExceptionProperties();
         AdditionalProperties additionalProperties = new AdditionalProperties();
         additionalProperties.setIncludeLocationInfo(true);
@@ -45,6 +50,7 @@ public class CustomLoggerNotificationListener
         if (config.getFlowCategorySuffix() != null && !config.getFlowCategorySuffix().equals("")) {
           logProperties.setCategorySuffix(config.getFlowCategorySuffix());
         }
+
         logProperties.setLevel(config.getFlowLogLevel());
         String logMessage = "Event not processed yet, this should never be shown";
         switch (Integer.parseInt(notification.getAction().getIdentifier())) {

--- a/src/test/java/com/avioconsulting/mule/logger/internal/CustomLoggerTest.java
+++ b/src/test/java/com/avioconsulting/mule/logger/internal/CustomLoggerTest.java
@@ -1,0 +1,119 @@
+package com.avioconsulting.mule.logger.internal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.avioconsulting.mule.logger.api.processor.AdditionalProperties;
+import com.avioconsulting.mule.logger.api.processor.ExceptionProperties;
+import com.avioconsulting.mule.logger.api.processor.LogProperties;
+import com.avioconsulting.mule.logger.api.processor.MessageAttributes;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.exception.MuleException;
+
+public class CustomLoggerTest {
+
+  private String examplePayload;
+  private String correlationId;
+  private String applicationName;
+  private String applicationVersion;
+  private String environment;
+  private String defaultCategory;
+  private Boolean enableV1Compatibility;
+
+  @Before
+  public void init() {
+    examplePayload = "Example Payload Text";
+    correlationId = "ab9195f8-0ff6-4611-ab78-63c60c824c95";
+    applicationName = "example-app-name";
+    applicationVersion = "1.0.0";
+    environment = "dev";
+    defaultCategory = "com.avioconsulting.mule";
+    enableV1Compatibility = false;
+  }
+
+  @Test
+  public void log_verifyLogPropertiesNoPayloadNoAttributes_test() {
+    // Initialize, create mocks and spys
+    CustomLogger customLogger = new CustomLogger();
+    LogProperties logProperties = new LogProperties();
+    LogProperties spyLogProperties = spy(logProperties);
+    MessageAttributes messageAttributes = new MessageAttributes();
+    MessageAttributes spyMessageAttributes = spy(messageAttributes);
+    when(spyLogProperties.getPayload()).thenReturn(null);
+
+    // Call method
+    customLogger.log(spyLogProperties,
+        spyMessageAttributes,
+        mock(ExceptionProperties.class),
+        mock(AdditionalProperties.class),
+        mock(ComponentLocation.class),
+        correlationId,
+        applicationName,
+        applicationVersion,
+        environment,
+        defaultCategory,
+        enableV1Compatibility);
+
+    // Assertions
+    // Assert log properties
+    Assert.assertEquals(null, spyLogProperties.getPayload());
+    // Assert Message Attributes
+    Assert.assertEquals(null, spyMessageAttributes.getOTelContext());
+    ArrayList emptyList = new ArrayList();
+    Assert.assertEquals(emptyList, spyMessageAttributes.getAttributeList());
+
+  }
+
+  @Test
+  public void log_traceAndSpanDataIsInMessageAttributes_test() throws MuleException, IOException {
+    CustomLogger customLogger = new CustomLogger();
+    LogProperties logProperties = new LogProperties();
+    LogProperties spyLogProperties = spy(logProperties);
+    MessageAttributes messageAttributes = new MessageAttributes();
+    MessageAttributes spyMessageAttributes = spy(messageAttributes);
+    String jsonString = "{" +
+        "\"traceId\": \"76d5bcae3d49ff2e1b5ace9f0dcbee42\"," +
+        "\"spanId\": \"fa6fbe46daf007b9\"," +
+        "\"spanIdLong\": \"18045851443427018681\"," +
+        "\"traceparent\": \"00-76d5bcae3d49ff2e1b5ace9f0dcbee42-fa6fbe46daf007b9-01\"," +
+        "\"TRACE_TRANSACTION_ID\": \"bfacf7c0-d583-11ee-adfa-bcd074a0357f\"," +
+        "\"traceIdLongLowPart\": \"1971114969454603842\"" +
+        "}";
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    Object dataObject = objectMapper.readValue(jsonString, Map.class);
+    spyMessageAttributes.setOTelContextObject(dataObject);
+
+    // Call method
+    customLogger.log(spyLogProperties,
+        spyMessageAttributes,
+        mock(ExceptionProperties.class),
+        mock(AdditionalProperties.class),
+        mock(ComponentLocation.class),
+        correlationId,
+        applicationName,
+        applicationVersion,
+        environment,
+        defaultCategory,
+        enableV1Compatibility);
+
+    // Assertions
+    // Assert log properties
+    Assert.assertEquals(null, spyLogProperties.getPayload());
+    // Assert Message Attributes
+    Assert.assertTrue(spyMessageAttributes.getOTelContextObject() != null);
+    Assert.assertEquals(4, spyMessageAttributes.getAttributeList().size());
+    Assert.assertEquals("76d5bcae3d49ff2e1b5ace9f0dcbee42", spyMessageAttributes.getAttributes().get("traceId"));
+    Assert.assertEquals("1971114969454603842", spyMessageAttributes.getAttributes().get("traceIdLongLowPart"));
+    Assert.assertEquals("fa6fbe46daf007b9", spyMessageAttributes.getAttributes().get("spanId"));
+    Assert.assertEquals("18045851443427018681", spyMessageAttributes.getAttributes().get("spanIdLong"));
+  }
+}

--- a/src/test/resources/custom-logger-config.xml
+++ b/src/test/resources/custom-logger-config.xml
@@ -6,9 +6,10 @@
 http://www.mulesoft.org/schema/mule/avio-logger http://www.mulesoft.org/schema/mule/avio-logger/current/mule-avio-logger.xsd">
 
     <avio-logger:config name="AVIO_Logger_Config" doc:name="AVIO Logger Config" doc:id="84bd2712-015b-46b8-93e9-94536774b8ad"
-                      applicationVersion="#['1']" compressor="GZIP" encryptionAlgorithm="PBEWithHmacSHA512AndAES_128" encryptionPassword="example"/>
+                      applicationVersion="#['1']" compressor="GZIP" encryptionAlgorithm="PBEWithHmacSHA512AndAES_128" encryptionPassword="example" enableFlowLogs="true"/>
 
     <flow name="custom-logger-configFlow" doc:id="0068e855-24dc-41a4-8e13-41ca38de99ba">
+        <set-variable value="#[{'traceId': '76d5bcae3d49ff2e1b5ace9f0dcbee42','spanId': 'fa6fbe46daf007b9','spanIdLong': '18045851443427018681','traceparent': '00-76d5bcae3d49ff2e1b5ace9f0dcbee42-fa6fbe46daf007b9-01','TRACE_TRANSACTION_ID': 'bfacf7c0-d583-11ee-adfa-bcd074a0357f','traceIdLongLowPart': '1971114969454603842'}]" doc:name="Set Variable" doc:id="d7a7dade-4453-40cb-97bc-3ca7034372c6" variableName="OTEL_TRACE_CONTEXT"/>
         <avio-logger:log doc:name="Custom logger" doc:id="3a7b6ada-78ef-4f32-a14d-df126c8f887d"
                          config-ref="AVIO_Logger_Config" correlationId="#['static-correlation-id']"
                          message="#['Added static correlation id on logger']"


### PR DESCRIPTION
New parameter added to capture OpenTelemetry context  - closes #51 

<img width="780" alt="image" src="https://github.com/avioconsulting/mule-custom-logger/assets/877286/6a977269-179d-4dbb-a0ec-b75e5df44618">

<img width="780" alt="image" src="https://github.com/avioconsulting/mule-custom-logger/assets/877286/bec7001f-4b9e-4bc7-905f-20f83030feee">
