### PR TITLE
fix: internal log level for flow-ref notifications

### DIFF
--- a/src/main/java/com/avioconsulting/mule/logger/internal/listeners/CustomLoggerFlowRefNotificationListener.java
+++ b/src/main/java/com/avioconsulting/mule/logger/internal/listeners/CustomLoggerFlowRefNotificationListener.java
@@ -58,7 +58,7 @@ public class CustomLoggerFlowRefNotificationListener
                 .debug("Not a flow-ref pre or post event being processed, existing without logging.");
             return;
         }
-        classLogger.info(message);
+        classLogger.debug(message);
         Map<String, String> flowLogAttributes = getFlowLogAttributes(notification);
         logMessage(location, notification.getEvent(), message, FLOW_REF_CATEGORY_SUFFIX,
             config.getFlowLogLevel(), flowLogAttributes);
@@ -66,7 +66,7 @@ public class CustomLoggerFlowRefNotificationListener
         classLogger.error("Error processing flow notification", e);
       }
     } else {
-      classLogger.debug(
+      classLogger.warn(
           "Configuration hasn't been supplied to notification listener yet, flow logs won't be generated.");
     }
   }

--- a/src/test/java/com/avioconsulting/mule/logger/CustomLoggerArtifactTest.java
+++ b/src/test/java/com/avioconsulting/mule/logger/CustomLoggerArtifactTest.java
@@ -2,7 +2,6 @@ package com.avioconsulting.mule.logger;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -56,6 +55,8 @@ public class CustomLoggerArtifactTest extends MuleArtifactFunctionalTestCase {
     CoreEvent coreEvent = flowRunner("custom-logger-flow-ref").run();
     Assert.assertNotNull(coreEvent);
     Awaitility.await().untilAsserted(() -> Assertions.assertThat(Files.readAllLines(UNIT_TEST_LOG_PATH))
-        .contains("Flow-ref with target [simple-subflow] start", "Flow-ref with target [simple-subflow] end"));
+        .filteredOn(line -> line.contains("Flow-ref with target [simple-subflow] start")
+            || line.contains("Flow-ref with target [simple-subflow] end"))
+        .hasSize(2));
   }
 }


### PR DESCRIPTION
An internal class logger message was being logged in `info` instead of `debug`, causing duplicated log messages for flow-ref start and end.